### PR TITLE
Fix code scanning alert no. 6: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/aiohttp/vulnerable_routes.py
+++ b/src/vulnpy/aiohttp/vulnerable_routes.py
@@ -1,7 +1,7 @@
 from aiohttp import web
 from vulnpy.common import get_template
 from vulnpy.trigger import TRIGGER_MAP, get_trigger
-
+import html
 
 def _get_user_input(request):
     return request.rel_url.query.get("user_input", "")
@@ -26,7 +26,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + html.escape(user_input) + "</p>"
 
         return web.Response(text=template, content_type="text/html")
 


### PR DESCRIPTION
Fixes [https://github.com/shunmugadigialert/python1-Ai/security/code-scanning/6](https://github.com/shunmugadigialert/python1-Ai/security/code-scanning/6)

To fix the problem, we need to ensure that any user input included in the HTML response is properly escaped to prevent XSS attacks. In Python, we can use the `html.escape()` function to escape special characters in the user input. This will convert characters like `<`, `>`, and `&` into their corresponding HTML entities, preventing them from being interpreted as HTML or JavaScript.

We will modify the `get_trigger_view` function to escape the `user_input` before including it in the `template`. Specifically, we will import the `html` module and use the `html.escape()` function to sanitize the `user_input`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
