### PR TITLE
Fix code scanning alert no. 5: Reflected server-side cross-site scripting

### DIFF
--- a/src/vulnpy/django/vulnerable.py
+++ b/src/vulnpy/django/vulnerable.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-
+from django.utils.html import escape
 try:
     from django.conf.urls import url as compat_url
 except ImportError:
@@ -33,7 +33,7 @@ def get_trigger_view(name, trigger):
         template = get_template("{}.html".format(name))
 
         if name == "xss" and trigger == "raw":
-            template += "<p>XSS: " + user_input + "</p>"
+            template += "<p>XSS: " + escape(user_input) + "</p>"
 
         return HttpResponse(template)
 


### PR DESCRIPTION
Fixes [https://github.com/shunmugadigialert/python1-Ai/security/code-scanning/5](https://github.com/shunmugadigialert/python1-Ai/security/code-scanning/5)

To fix the problem, we need to ensure that any user input included in the HTML response is properly escaped to prevent XSS attacks. In Django, we can use the `django.utils.html.escape` function to escape user input before including it in the response.

The best way to fix this issue without changing existing functionality is to import the `escape` function from `django.utils.html` and use it to escape the `user_input` before concatenating it into the `template` string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
